### PR TITLE
Allow passing in custom credential for get temporary credential

### DIFF
--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -414,7 +414,7 @@ getTemporaryCredentialProxy :: MonadIO m
                             -> Credential
                             -> Manager
                             -> m Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredentialProxy p oa m c = getTemporaryCredential' (addMaybeProxy p) oa c m
+getTemporaryCredentialProxy p oa c m = getTemporaryCredential' (addMaybeProxy p) oa c m
 
 
 getTemporaryCredential' :: MonadIO m

--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -414,7 +414,7 @@ getTemporaryCredentialProxy :: MonadIO m
                             -> Credential
                             -> Manager
                             -> m Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredentialProxy p oa m c = getTemporaryCredential' (addMaybeProxy p) oa m c
+getTemporaryCredentialProxy p oa m c = getTemporaryCredential' (addMaybeProxy p) oa c m
 
 
 getTemporaryCredential' :: MonadIO m
@@ -423,7 +423,7 @@ getTemporaryCredential' :: MonadIO m
                         -> Credential
                         -> Manager
                         -> m Credential    -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredential' hook oa manager defaultCred = do
+getTemporaryCredential' hook oa defaultCred manager = do
   let req = fromJust $ parseUrl $ oauthRequestUri oa
       crd = maybe id (insert "oauth_callback") (oauthCallback oa) $ defaultCred
   req' <- signOAuth' oa crd False addAuthHeader $ hook (req { method = "POST" })

--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -391,8 +391,8 @@ bodyHash req bodyHashMethod =
 -- | Get temporary credential for requesting acces token.
 getTemporaryCredential :: MonadIO m
                        => OAuth         -- ^ OAuth Application
-                       -> Manager
                        -> Credential
+                       -> Manager
                        -> m Credential -- ^ Temporary Credential (Request Token & Secret).
 getTemporaryCredential = getTemporaryCredential' id
 
@@ -401,8 +401,8 @@ getTemporaryCredential = getTemporaryCredential' id
 getTemporaryCredentialWithScope :: MonadIO m
                                 => BS.ByteString -- ^ Scope parameter string
                                 -> OAuth         -- ^ OAuth Application
-                                -> Manager
                                 -> Credential
+                                -> Manager
                                 -> m Credential -- ^ Temporay Credential (Request Token & Secret).
 getTemporaryCredentialWithScope bs = getTemporaryCredential' (addScope bs)
 
@@ -411,8 +411,8 @@ getTemporaryCredentialWithScope bs = getTemporaryCredential' (addScope bs)
 getTemporaryCredentialProxy :: MonadIO m
                             => Maybe Proxy   -- ^ Proxy
                             -> OAuth         -- ^ OAuth Application
-                            -> Manager
                             -> Credential
+                            -> Manager
                             -> m Credential -- ^ Temporary Credential (Request Token & Secret).
 getTemporaryCredentialProxy p oa m c = getTemporaryCredential' (addMaybeProxy p) oa m c
 
@@ -420,8 +420,8 @@ getTemporaryCredentialProxy p oa m c = getTemporaryCredential' (addMaybeProxy p)
 getTemporaryCredential' :: MonadIO m
                         => (Request -> Request)       -- ^ Request Hook
                         -> OAuth                      -- ^ OAuth Application
-                        -> Manager
                         -> Credential
+                        -> Manager
                         -> m Credential    -- ^ Temporary Credential (Request Token & Secret).
 getTemporaryCredential' hook oa manager defaultCred = do
   let req = fromJust $ parseUrl $ oauthRequestUri oa

--- a/authenticate-oauth/Web/Authenticate/OAuth/IO.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth/IO.hs
@@ -32,7 +32,7 @@ import qualified Data.ByteString.Char8 as BS
 getTemporaryCredential :: MonadIO m
                        => OA.OAuth        -- ^ OAuth Application
                        -> m OA.Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredential = liftIO . withManager defaultManagerSettings . OA.getTemporaryCredential OA.emptyCredential
+getTemporaryCredential oa = liftIO . withManager defaultManagerSettings . OA.getTemporaryCredential oa OA.emptyCredential
 
 -- | Get temporary credential for requesting access token with Scope parameter.
 getTemporaryCredentialWithScope :: MonadIO m

--- a/authenticate-oauth/Web/Authenticate/OAuth/IO.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth/IO.hs
@@ -32,7 +32,7 @@ import qualified Data.ByteString.Char8 as BS
 getTemporaryCredential :: MonadIO m
                        => OA.OAuth        -- ^ OAuth Application
                        -> m OA.Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredential oa = liftIO . withManager defaultManagerSettings . OA.getTemporaryCredential oa OA.emptyCredential
+getTemporaryCredential oa = liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredential oa OA.emptyCredential
 
 -- | Get temporary credential for requesting access token with Scope parameter.
 getTemporaryCredentialWithScope :: MonadIO m

--- a/authenticate-oauth/Web/Authenticate/OAuth/IO.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth/IO.hs
@@ -32,7 +32,7 @@ import qualified Data.ByteString.Char8 as BS
 getTemporaryCredential :: MonadIO m
                        => OA.OAuth        -- ^ OAuth Application
                        -> m OA.Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredential = liftIO . withManager defaultManagerSettings . OA.getTemporaryCredential
+getTemporaryCredential = liftIO . withManager defaultManagerSettings . OA.getTemporaryCredential OA.emptyCredential
 
 -- | Get temporary credential for requesting access token with Scope parameter.
 getTemporaryCredentialWithScope :: MonadIO m
@@ -40,7 +40,7 @@ getTemporaryCredentialWithScope :: MonadIO m
                                 -> OAuth         -- ^ OAuth Application
                                 -> m Credential -- ^ Temporay Credential (Request Token & Secret).
 getTemporaryCredentialWithScope bs oa =
-  liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredentialWithScope bs oa
+  liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredentialWithScope bs oa OA.emptyCredential
 
 
 -- | Get temporary credential for requesting access token via the proxy.
@@ -48,13 +48,13 @@ getTemporaryCredentialProxy :: MonadIO m
                             => Maybe Proxy   -- ^ Proxy
                             -> OAuth         -- ^ OAuth Application
                             -> m Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredentialProxy p oa = liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredential' (addMaybeProxy p) oa
+getTemporaryCredentialProxy p oa = liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredential' (addMaybeProxy p) oa OA.emptyCredential
 
 getTemporaryCredential' :: MonadIO m
                         => (Request -> Request)                                 -- ^ Request Hook
                         -> OAuth                      -- ^ OAuth Application
                         -> m Credential -- ^ Temporary Credential (Request Token & Secret).
-getTemporaryCredential' hook oa = liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredential' hook oa
+getTemporaryCredential' hook oa = liftIO $ withManager defaultManagerSettings $ OA.getTemporaryCredential' hook oa OA.emptyCredential
 
 
 -- | Get Access token.


### PR DESCRIPTION
NetSuite's OAuth 1.0a implementation allows us to pass a `state` value -- so this PR allows us to pass in a default credential map which can include this `state` value.